### PR TITLE
Added Cloud Seeder 1 click installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@
 
 ## Resources
 
-- [Cloud Seeder](https://ipv6.rs/cloudseeder) - 1 click installer and updater for Prowlarr, Lidarr, Radarr, Readarr, Sonarr and Whisparr. Also links and connects qBittorrent. See [YouTube](https://www.youtube.com/watch?v=PrH6Ci_4eig).
 - [Servarr](https://wiki.servarr.com/) -  The consolidated wiki for Lidarr, Prowlarr, Radarr, Readarr, and Sonarr.
 - [TRaSH-Guides](https://trash-guides.info/) - Guides mainly for Sonarr/Radarr/Bazarr and everything related to it.
 - [Snackbox](https://discord.gg/snackbox) - Discord community with a focus on private trackers, releases, and \*arrs.
@@ -61,6 +60,7 @@
 - [Bazarr](https://github.com/morpheus65535/bazarr) - Bazarr is a companion application to Sonarr and Radarr. It manages and downloads subtitles based on your requirements. You define your preferences by TV show or movie and Bazarr takes care of everything for you.
 - [Buildarr](https://github.com/buildarr/buildarr) - A solution to automating deployment and configuration of your *arr stack.
 - [Checkrr](https://github.com/aetaric/checkrr) - Checkrr Scans your library files for corrupt media and replace the files via sonarr and radarr.
+- [Cloud Seeder](https://ipv6.rs/cloudseeder) - 1 click installer and updater for Prowlarr, Lidarr, Radarr, Readarr, Sonarr and Whisparr. Also links and connects qBittorrent.
 - [Collectarr](https://github.com/RiffSphere/Collectarr) - A Python script for checking your Radarr database and setting up collection lists. Also supports "smart" actor lists based on TMDB.
 - [Crossarr](https://github.com/TMD20/crossarr) - Cross Seed via Arr Programs.
 - [Deleterr](https://github.com/rfsbraz/deleterr) - Automates deleting inactive and stale media from Plex/Sonarr/Radarr.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 
 ## Resources
 
+- [Cloud Seeder](https://ipv6.rs/cloudseeder) - 1 click installer and updater for Prowlarr, Lidarr, Radarr, Readarr, Sonarr and Whisparr. Also links and connects qBittorrent. See [YouTube](https://www.youtube.com/watch?v=PrH6Ci_4eig).
 - [Servarr](https://wiki.servarr.com/) -  The consolidated wiki for Lidarr, Prowlarr, Radarr, Readarr, and Sonarr.
 - [TRaSH-Guides](https://trash-guides.info/) - Guides mainly for Sonarr/Radarr/Bazarr and everything related to it.
 - [Snackbox](https://discord.gg/snackbox) - Discord community with a focus on private trackers, releases, and \*arrs.


### PR DESCRIPTION
Added link to Cloud Seeder as well as a YouTube Video (https://www.youtube.com/watch?v=PrH6Ci_4eig)

Cloud Seeder installers qBittorrent, and the *Arr suite of apps, prelinks them, and gets everything running on a DNS for you with just a click (Windows, MacOS and Linux).

Thank you!