### PR TITLE
Remove LunaSea

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,5 @@
 
 ## Mobile Apps
 
-- [LunaSea](https://github.com/JagandeepBrar/LunaSea) - LunaSea is a fully featured, open source self-hosted controller focused on giving you a seamless experience between all of your self-hosted media software remotely on your devices. LunaSea currently supports Lidarr, Radarr, Sonarr, NZBGet, SABnzbd, Newznab, Indexer Searching, NZBHydra2, Tautulli, and Wake on LAN.
 - [Ruddarr](https://github.com/ruddarr/app) - Ruddarr is a beautifully designed, open source, iOS/iPadOS companion app for Radarr and Sonarr instances written in SwiftUI.
 - [nzb360](https://nzb360.com/) - Usenet/Torrent manager for Android. Supports SABnzbd, NZBget, Deluge, Transmission, uTorrent, qBittorrent, rTorrent/ruTorrent, Sonarr, Sick Beard, Radarr, Lidarr, Bazarr, Couchpotato, Headphones, Readarr, NEWZnab, Jackett, NZBHydra2 and Prowlarr.


### PR DESCRIPTION
LunaSea is EOL and the servers have been taken offline as of 2025-04-30, according to https://www.lunasea.app.

<!-- 
# Contribution Guidelines

Please note that this project is released with a
[Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this
project you agree to abide by its terms.

---

Ensure your pull request adheres to the following guidelines:

- Follow the format `- [Name](link) - A small description.`
- Maintain alphabetical order in each category.
- Submitted projects must meet a popularity threshold:
    - **GitHub:** Minimum 50 stars.
    - **Other Platforms:** Comparable community interest.

I apologize if this feels like an arbitrary hurdle. Unfortunately, to keep this list focused and manageable, 
and to ensure it highlights projects that have demonstrated some level of community validation, 
I need a way to fairly filter submissions. I simply cannot include every project, and without some kind of metric, 
reviewing and rejecting projects becomes very subjective and unsustainable.

This check is an attempt to introduce a degree of fairness and objectivity to the process. Thank you for your understanding.
-->
