### PR TITLE
Add iPlayarr to list of *arr companions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 - [Flemmarr](https://github.com/Flemmarr/Flemmarr) - Flemmarr makes it easy to automate configuration for your -arr apps.
 - [Gclone](https://github.com/l3v11/gclone) - A rclone mod with auto SA rotation.
 - [Huntarr](https://github.com/plexguide/Huntarr.io) - A specialized utility that automates discovering missing and upgrading your media collection!
+- [iPlayarr](https://github.com/Nikorag/iplayarr) – Download-automation for BBC iPlayer — integrates with Sonarr/Radarr as a Newznab API endpoint.
 - [Janitorr](https://github.com/Schaka/janitorr) - Cleans your Radarr, Sonarr, Jellyseerr and Jellyfin before you run out of space.
 - [Jellyseerr](https://github.com/Fallenbagel/jellyseerr) - Open-source media request and discovery manager for Jellyfin, Plex and Emby.
 - [Just A Bunch Of Starr Scripts](https://github.com/angrycuban13/Just-A-Bunch-Of-Starr-Scripts) - PowerShell scripts for Starr apps.


### PR DESCRIPTION
Add iPlayarr – BBC iPlayer automation companion for Sonarr/Radarr

<!-- 
# Contribution Guidelines

Please note that this project is released with a
[Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this
project you agree to abide by its terms.

---

Ensure your pull request adheres to the following guidelines:

- Follow the format `- [Name](link) - A small description.`
- Maintain alphabetical order in each category.
- Submitted projects must meet a popularity threshold:
    - **GitHub:** Minimum 50 stars.
    - **Other Platforms:** Comparable community interest.

I apologize if this feels like an arbitrary hurdle. Unfortunately, to keep this list focused and manageable, 
and to ensure it highlights projects that have demonstrated some level of community validation, 
I need a way to fairly filter submissions. I simply cannot include every project, and without some kind of metric, 
reviewing and rejecting projects becomes very subjective and unsustainable.

This check is an attempt to introduce a degree of fairness and objectivity to the process. Thank you for your understanding.
-->
