### PR TITLE
Add Admirarr — unified CLI for the *Arr fleet with diagnostics and AI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 
 ## Complimenting Apps
 
+- [Admirarr](https://github.com/maxtechera/admirarr) - Unified CLI for your *Arr fleet. Deploy, diagnose, and operate Radarr, Sonarr, Prowlarr, Jellyfin/Plex, qBittorrent, Gluetun, Seerr, Bazarr from one terminal. 26 commands, 34 diagnostic checks, JSON output, AI agent native via SKILL.md.
 - [Arr-scripts](https://github.com/RandomNinjaAtk/arr-scripts) - Extended Container Scripts. Designed to be easily implemented/added to Linuxserver.io containers.
 - [Autobrr](https://autobrr.com/) - The modern autodl-irssi replacement.
 - [Autopulse](https://github.com/dan-online/autopulse) - An automated lightweight service that updates media servers like Plex and Jellyfin based on notifications from media organizers like Sonarr and Radarr.


### PR DESCRIPTION
## What is Admirarr?

[Admirarr](https://github.com/maxtechera/admirarr) is a zero-dependency CLI for managing your entire \*Arr fleet from one terminal.

**Why it belongs in awesome-arr:**
- Natively integrates with Radarr, Sonarr, Prowlarr, qBittorrent, Gluetun, Seerr, Bazarr, Jellyfin/Plex, Recyclarr, FlareSolverr + 14 optional services
- 26 commands: `status`, `doctor`, `setup`, `add-movie`, `add-show`, `search`, `downloads`, `queue`, `missing`, `indexers`, `recyclarr sync`, `restart`, `logs`, and more
- 15 diagnostic categories, 34 checks — `doctor --fix` mode with deterministic repairs
- JSON output everywhere for shell composition
- Ships `SKILL.md` (Agent Skills standard) — AI agents auto-discover and operate your fleet

**Quick start:**
```bash
curl -fsSL https://get.admirarr.dev | sh
admirarr status    # full fleet view
admirarr doctor    # 34 diagnostic checks
```

Added alphabetically under **Complimenting Apps** — fits squarely alongside Buildarr, Deployarr, and similar stack management tools.

Repo: https://github.com/maxtechera/admirarr · Release: [v0.1.0](https://github.com/maxtechera/admirarr/releases/tag/v0.1.0)