### PR TITLE
Add Admirarr — unified CLI + AI agent skill for Jellyfin/Plex + *Arr stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 
 ## Complimenting Apps
 
+- [Admirarr](https://github.com/maxtechera/admirarr) - Unified CLI for Jellyfin/Plex + *Arr stacks — deploy, configure, diagnose, and operate your fleet from a single binary with AI agent support via SKILL.md.
 - [Arr-scripts](https://github.com/RandomNinjaAtk/arr-scripts) - Extended Container Scripts. Designed to be easily implemented/added to Linuxserver.io containers.
 - [Autobrr](https://autobrr.com/) - The modern autodl-irssi replacement.
 - [Autopulse](https://github.com/dan-online/autopulse) - An automated lightweight service that updates media servers like Plex and Jellyfin based on notifications from media organizers like Sonarr and Radarr.


### PR DESCRIPTION
## What is Admirarr?

[Admirarr](https://github.com/maxtechera/admirarr) is a unified CLI for Jellyfin/Plex + \*Arr media server stacks.

**One binary, 26 commands, JSON output everywhere.** Deploy, configure, diagnose, and operate your entire fleet from a single terminal — human and AI agent operated.

### Key capabilities
- `admirarr setup` — Zero to media server in 15 minutes (12-phase automated deployment)
- `admirarr doctor` — 15 diagnostic categories, 34 checks, AI-powered repair
- `admirarr status` — Fleet dashboard with live TUI mode
- Covers Jellyfin, Plex, Radarr, Sonarr, Prowlarr, qBittorrent, Gluetun, Seerr, Bazarr, FlareSolverr, and 14 optional services
- Ships with `SKILL.md` — works with Claude Code, Cursor, OpenCode, VS Code Copilot, Gemini CLI, and 20+ AI agent platforms

### Install
```bash
curl -fsSL https://get.admirarr.dev | sh
```

- **Homepage**: https://github.com/maxtechera/admirarr
- **License**: MIT
- **Language**: Go (single binary, zero deps)

> Note: This project was released in March 2026 and is actively maintained. Starring and community feedback welcome!