### PR TITLE
Add Digarr

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 - [Decluttarr](https://github.com/ManiMatter/decluttarr) - Watches radarr, sonarr, lidarr and whisparr download queues and removes downloads if they become stalled or no longer needed.
 - [Deleterr](https://github.com/rfsbraz/deleterr) - Automates deleting inactive and stale media from Plex/Sonarr/Radarr.
 - [Deployrr](https://github.com/SimpleHomelab/Deployrr) - Automates Homelab setup using Docker and Docker Compose.
+- [Digarr](https://github.com/iuliandita/digarr) - AI-powered music discovery that builds a taste profile from your listening sources and finds new artists. Optionally sends approved artists straight to Lidarr.
 - [Episeerr](https://github.com/Vansmak/episeerr) - Automates sending and deleting episodes or seasons to sonarr one at a time as played.
 - [Excludarr](https://github.com/haijeploeg/excludarr) - A CLI that interacts with Radarr and Sonarr instances. It completely manages you library in Sonarr and Radarr to only consist out of movies and series that are not present on any of the configured streaming providers.
 - [Exportarr](https://github.com/onedr0p/exportarr) - This will export metrics gathered from Sonarr, Radarr, Lidarr, or Prowlarr.


### PR DESCRIPTION
Adding [Digarr](https://github.com/iuliandita/digarr) to the Complimenting Apps section.

Digarr is a self-hosted music discovery tool that connects to your listening sources (ListenBrainz, Last.fm, Spotify, Plex, Jellyfin, Discogs) and uses AI to find new artists you'd actually like. A few highlights:

- **7-stage discovery pipeline** - collects listening history, analyzes taste, discovers candidates, resolves metadata via MusicBrainz, scores with a weighted formula, filters duplicates, and stores results
- **Lidarr integration** (optional) - approved artists get added directly to Lidarr. Works without Lidarr too, as a standalone discovery tool
- **Mood-based discovery** - describe what you're in the mood for in plain English and get instant results
- **Subscriptions** - set up recurring discovery jobs that find new music on a schedule
- **Auto-generated playlists** - weekly digest playlists pushed to Spotify or your media server
- **Multi-user with OIDC/SSO support**

MIT licensed, Docker/Helm ready, 1200+ tests.