### PR TITLE
Fix Requestrr GitHub link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@
 - [Doplarr](https://github.com/kiranshila/Doplarr) - An *arr request bot for Discord.
 - [jackett2telegram](https://github.com/danimart1991/jackett2telegram) - A self-hosted Telegram Python Bot that dumps posts from Jackett RSS feeds to a Telegram chat.
 - [Membarr](https://github.com/Yoruio/Membarr) - Discord Bot to invite a user to a Plex or Jellyfin server.
-- [Requestrr](https://github.com/darkalfx/requestrr) - A Discord bot used to simplify using services like Sonarr/Radarr/Ombi via the use of chat.
+- [Requestrr](https://github.com/thomst08/requestrr) - A Discord bot used to simplify using services like Sonarr/Radarr/Ombi via the use of chat.
 - [Searcharr](https://github.com/toddrob99/searcharr) - Sonarr & Radarr Telegram Bot.
 
 ## Dashboards


### PR DESCRIPTION
## Submission

- Updated Requestrr link to point to the fork repository as original was retired in 2024.

---

## Requirements

- [x] Entry uses format: `- [Name](link) - Description`
- [x] Entry is in alphabetical order within its section
- [x] Project has >=100 GitHub stars (if hosted on GitHub)[^1]
- [x] Project is at least 1 year old (from first public release)
- [x] Project shows recent activity (within ~12 months)
- [x] Project is not mostly auto-generated[^2]
- [x] This PR was written by a human. If you do not have time to write it yourself, I do not have time to review it

Submissions that do not meet these criteria may be closed without review.

[^1]: Not a strict requirement, interesting projects may still be considered even if they have fewer stars.
[^2]: Any use of AI in the project must be disclosed honestly in the project itself (e.g., in the README or documentation).
