### PR TITLE
Added "Fetcharr" to Complimenting Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [Excludarr](https://github.com/haijeploeg/excludarr) - A CLI that interacts with Radarr and Sonarr instances. It completely manages you library in Sonarr and Radarr to only consist out of movies and series that are not present on any of the configured streaming providers.
 - [Exportarr](https://github.com/onedr0p/exportarr) - This will export metrics gathered from Sonarr, Radarr, Lidarr, or Prowlarr.
 - [Ezarr](https://github.com/Luctia/ezarr) - Aims to make it as easy as possible to setup an entire Servarr/Jackett/BitTorrent/PleX/Jellyfin mediacenter stack using Docker.
+- [Fetcharr](https://github.com/furey/fetcharr) - Syncs Fetch TV PVR recordings into Plex. Watches a Fetch TV box on the LAN, copies new episodes of followed shows into the Plex TV library, and triggers a section refresh.
 - [Nixarr](https://github.com/nix-media-server/nixarr) - A Nixos module that aims to make the installation and management of a home media server as easy, and pain free, as possible.
 - [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) - Proxy server to bypass Cloudflare protection.
 - [Flemmarr](https://github.com/Flemmarr/Flemmarr) - Easy, automatic configuration for your -arr apps.


### PR DESCRIPTION
## Submission

- [Fetcharr](https://github.com/furey/fetcharr) - Syncs Fetch TV PVR recordings into Plex. Watches a Fetch TV box on the LAN, copies new episodes of followed shows into the Plex TV library, and triggers a section refresh.

Note: Fetcharr was made public at v1.0.0 in May 2026, so it does not yet meet the ≥100-stars or ≥1-year-old criteria.

---

## Requirements

- [x] Entry uses format: `- [Name](link) - Description`
- [x] Entry is in alphabetical order within its section
- [ ] Project has >=100 GitHub stars (if hosted on GitHub)
- [ ] Project is at least 1 year old (from first public release)
- [x] Project shows recent activity (within ~12 months)
- [x] Project is not mostly auto-generated
- [x] This PR was written by a human.