### PR TITLE
Add Arrcade to Mobile Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,5 +153,6 @@
 
 ## Mobile Apps
 
+- [Arrcade](https://arrcade.co.uk) - Cross-platform controller for Sonarr, Radarr, Prowlarr, download clients and Seerr, managed from one account on iOS and the web, with Android in beta. Closed source with a free tier.
 - [Ruddarr](https://github.com/ruddarr/app) - A beautifully designed, open source, iOS/iPadOS companion app for Radarr and Sonarr instances written in SwiftUI.
 - [nzb360](https://nzb360.com/) - Usenet/Torrent manager for Android. Supports SABnzbd, NZBget, Deluge, Transmission, uTorrent, qBittorrent, rTorrent/ruTorrent, Sonarr, Sick Beard, Radarr, Lidarr, Bazarr, Couchpotato, Headphones, NEWZnab, Jackett, NZBHydra2 and Prowlarr.


### PR DESCRIPTION
Adds Arrcade to the Mobile Apps list.

[Arrcade](https://arrcade.co.uk) is a cross-platform controller for Sonarr, Radarr, Prowlarr, download clients, and Seerr, managed from one account. It is available on iOS (App Store) and the web now, with Android in beta. Closed source with a free tier.

Placed alphabetically at the top of the Mobile Apps section.